### PR TITLE
typo correction

### DIFF
--- a/lib/src/main/res/values-el/strings.xml
+++ b/lib/src/main/res/values-el/strings.xml
@@ -182,19 +182,19 @@
     <string name="content__file__status__default">%1$s</string>
     <string name="content__file__status__uploading__minimized">Μεταφόρτωση&#8230;</string>
     <string name="content__file__status__cancelled__minimized">Ακυρώθηκε&#8230;</string>
-    <string name="content__file__status__downloading__minimized">Γίνετε λήψη&#8230;</string>
+    <string name="content__file__status__downloading__minimized">Γίνεται λήψη&#8230;</string>
     <string name="content__file__status__download_failed__minimized">Η λήψη απέτυχε</string>
     <string name="content__file__status__upload_failed__minimized">Η μεταφόρτωση απέτυχε</string>
     <string name="content__file__status__uploading">%1$s · Μεταφόρτωση&#8230;</string>
     <string name="content__file__status__cancelled">%1$s · Ακυρώθηκε&#8230;</string>
-    <string name="content__file__status__downloading">%1$s · Γίνετε λήψη&#8230;</string>
+    <string name="content__file__status__downloading">%1$s · Γίνεται λήψη&#8230;</string>
     <string name="content__file__status__download_failed">%1$s · Η λήψη απέτυχε</string>
     <string name="content__file__status__upload_failed">%1$s · Η μεταφόρτωση απέτυχε</string>
     <!-- used when there's a non-empty file extension, e.g. "300KB · PDF" -->
     <string name="content__file__status__default__size_and_extension">%1$s · %2$s</string>
     <string name="content__file__status__uploading__size_and_extension">%1$s · %2$s · Μεταφόρτωση&#8230;</string>
     <string name="content__file__status__cancelled__size_and_extension">%1$s · %2$s · Ακυρώθηκε&#8230;</string>
-    <string name="content__file__status__downloading__size_and_extension">%1$s · %2$s · Γίνετε λήψη&#8230;</string>
+    <string name="content__file__status__downloading__size_and_extension">%1$s · %2$s · Γίνεται λήψη&#8230;</string>
     <string name="content__file__status__download_failed__size_and_extension">%1$s · %2$s · Η λήψη απέτυχε</string>
     <string name="content__file__status__upload_failed__size_and_extension">%1$s · %2$s · Η μεταφόρτωση απέτυχε</string>
     <string name="content__file__action__open">Άνοιγμα</string>
@@ -723,7 +723,7 @@
     <string name="otr__participant__my_device__description">Αποτυπώματα της συσκευής σας</string>
     <string name="otr__participant__my_device__show_all_devices_link">Εμφάνιση όλων των συσκευών μου</string>
     <string name="otr__participant__single_device__description">Βεβαιωθείτε ότι ταιριάζει με το αποτύπωμα που εμφανίζεται στην %1$s\'s συσκευή.</string>
-    <string name="otr__participant__single_device__how_to_link">_Πως γίνετε αυτό;_</string>
+    <string name="otr__participant__single_device__how_to_link">_Πως γίνεται αυτό;_</string>
     <string name="otr__device_id">ID: %s</string>
     <string name="otr__first_launch__header">Είναι η πρώτη φορά που χρησιμοποιείτε το Wire σε αυτή την συσκευή.</string>
     <string name="otr__first_launch__sub_header">Για λόγους απορρήτου, το ιστορικό συνομιλιών σας δεν θα εμφανίζεται εδώ.</string>


### PR DESCRIPTION
greek typo correction of the word "γίνεται" (4 cases of "γίνετε" changed to "γίνεται")